### PR TITLE
Create import and export features

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,8 @@
     "angular-ui-layout": "~1.3.0",
     "angular-ui-tree": "~2.9.0",
     "file-saver": "*",
+    "blob": "*",
+    "angular-file-saver": "^1.1.3",
     "js-xlsx": "~0.8.0",
     "jquery": "~2.1.4",
     "jquery-ui": "~1.11.4",

--- a/public/js/io/controller.js
+++ b/public/js/io/controller.js
@@ -1,0 +1,117 @@
+app.controller('ioCtrl', function ($scope, $rootScope, connection, $routeParams, ioModel, FileSaver, Upload) {
+    $scope.layers = [];
+    $scope.reports = [];
+    $scope.dashboards = [];
+
+    $scope.exportName = 'export';
+
+    $scope.state = 1;
+
+    $scope.matchAllDatasourcesMessage = false;
+
+    $scope.initExport = async function () {
+        $scope.layers = await ioModel.getLayers();
+        $scope.reports = await ioModel.getReports();
+        $scope.dashboards = await ioModel.getDashboards();
+        $scope.$digest();
+    };
+
+    $scope.initImport = async function () {
+        $scope.importFile = undefined;
+        $scope.state = 1;
+        $scope.fileReader = new FileReader();
+    };
+
+    $scope.downloadExport = async function () {
+        var layerIDs = [];
+        var reportIDs = [];
+        var dashboardIDs = [];
+
+        for (const layer of $scope.layers) {
+            if (layer.checked) {
+                layerIDs.push(layer._id);
+            }
+        }
+
+        for (const report of $scope.reports) {
+            if (report.checked) {
+                reportIDs.push(report._id);
+            }
+        }
+
+        for (const dashboard of $scope.dashboards) {
+            if (dashboard.checked) {
+                dashboardIDs.push(dashboard._id);
+            }
+        }
+
+        const bundle = await ioModel.makeExportBundle(dashboardIDs, reportIDs, layerIDs);
+
+        FileSaver.saveAs(new Blob([JSON.stringify(bundle)]), $scope.exportName + '.json');
+    };
+
+    $scope.upload = function (file) {
+        $scope.fileReader.readAsText(file);
+        $scope.fileReader.onload = function () {
+            try {
+                $scope.importFile = JSON.parse($scope.fileReader.result);
+                if (!($scope.importFile.layerExports && $scope.importFile.reportExports &&
+                    $scope.importFile.datasourceExports && $scope.importFile.dashboardExports)) {
+                    var error = Object();
+                    error['msg'] = 'missing fields';
+                    throw error;
+                }
+            } catch (err) {
+                console.log('invalid file format');
+                console.log(err);
+                $scope.importFile = undefined;
+            }
+            $scope.$digest();
+        };
+    };
+
+    function autoDetect (dts) {
+        for (const localDts of $scope.localDataSources) {
+            if (localDts.name === dts.name) {
+                return localDts;
+            }
+        }
+    }
+
+    $scope.startImport = async function () {
+        $scope.datasourceMatch = {};
+        $scope.localDataSources = await ioModel.getDataSources();
+        for (const dts of $scope.importFile.datasourceExports) {
+            $scope.datasourceMatch[dts._id] = autoDetect(dts);
+        }
+
+        $scope.state = 2;
+        $scope.$digest();
+    };
+
+    $scope.confirmImport = function () {
+        var datasourceRef = {};
+        for (const dtsID in $scope.datasourceMatch) {
+            if (!$scope.datasourceMatch[dtsID]) {
+                $scope.matchAllDatasourcesMessage = true;
+                return;
+            }
+            datasourceRef[dtsID] = $scope.datasourceMatch[dtsID]._id;
+        }
+        ioModel.importBundle($scope.importFile, datasourceRef).then(function (result) {
+            $scope.state = 3;
+            $scope.created = result;
+            $scope.$digest();
+        },
+        function (error) {
+            $scope.state = 4;
+            $scope.created = false;
+            $scope.creationError = error;
+            $scope.$digest();
+        });
+    };
+
+    $scope.cancelImport = function () {
+        $scope.state = 1;
+    };
+});

--- a/public/js/io/model.js
+++ b/public/js/io/model.js
@@ -104,7 +104,9 @@ app.service('ioModel', function (connection) {
 
     async function importLayer (layer, datasourceRef, additions) {
         var params = {
-            _id: layer._id
+            find: [
+                { _id: layer._id }
+            ]
         };
 
         var existingLayer = await connection.get('/api/layers/find-all', params);
@@ -126,7 +128,9 @@ app.service('ioModel', function (connection) {
 
     async function importReport (report, datasourceRef, additions) {
         var params = {
-            _id: report._id
+            find: [
+                { _id: report._id }
+            ]
         };
 
         var existingReport = await connection.get('/api/reports/find-all', params);
@@ -162,7 +166,9 @@ app.service('ioModel', function (connection) {
 
     async function importDashboard (dashboard, datasourceRef, additions) {
         var params = {
-            _id: dashboard._id
+            find: [
+                { _id: dashboard._id }
+            ]
         };
 
         var existingDashboard = await connection.get('/api/dashboardsv2/find-all', params);

--- a/public/js/io/model.js
+++ b/public/js/io/model.js
@@ -1,0 +1,258 @@
+app.service('ioModel', function (connection) {
+    async function exportDataSource (datasourceID) {
+        var params = {
+            id: datasourceID
+        };
+
+        const result = await connection.get('/api/data-sources/find-one', params);
+
+        return result.item;
+    }
+
+    async function exportLayer (layerID, requiredDataSources) {
+        var params = {
+            id: layerID
+        };
+
+        var result = await connection.get('/api/layers/find-one', params);
+
+        for (const object of result.item.objects) {
+            if (object.datasourceID) {
+                requiredDataSources.add(object.datasourceID);
+            }
+        }
+
+        return result.item;
+    }
+
+    async function exportReport (reportID, requiredLayers, requiredDataSources) {
+        var params = {
+            id: reportID
+        };
+
+        var result = await connection.get('/api/reports/find-one', params);
+        for (const layerID of result.item.query.layers) {
+            requiredLayers.add(layerID);
+        }
+
+        for (const datasource of result.item.query.datasources) {
+            requiredDataSources.add(datasource.datasourceID);
+        }
+
+        delete result.item.query.data;
+
+        return result.item;
+    }
+
+    async function exportDashboard (dashboardID, requiredLayers, requiredDataSources) {
+        var params = {
+            id: dashboardID
+        };
+
+        var result = await connection.get('/api/dashboardsv2/find-one', params);
+
+        for (const report of result.item.reports) {
+            for (const layerID of report.query.layers) {
+                requiredLayers.add(layerID);
+            }
+            for (const datasource of report.query.datasources) {
+                requiredDataSources.add(datasource.datasourceID);
+            }
+
+            delete report.query.data;
+        }
+
+        return result.item;
+    }
+
+    this.makeExportBundle = async function (dashboardIDs, reportIDs, layerIDs) {
+        var requiredLayers = new Set();
+        var requiredDataSources = new Set();
+
+        var dashboardExports = [];
+        var reportExports = [];
+        var layerExports = [];
+        var datasourceExports = [];
+
+        for (const layerID of layerIDs) {
+            requiredLayers.add(layerID);
+        }
+
+        for (const reportID of reportIDs) {
+            reportExports.push(await exportReport(reportID, requiredLayers, requiredDataSources));
+        }
+
+        for (const dashboardID of dashboardIDs) {
+            dashboardExports.push(await exportDashboard(dashboardID, requiredLayers, requiredDataSources));
+        }
+
+        for (const layerID of requiredLayers.entries()) {
+            layerExports.push(await exportLayer(layerID, requiredDataSources));
+        }
+
+        for (const datasourceID of requiredDataSources.entries()) {
+            datasourceExports.push(await exportDataSource(datasourceID));
+        }
+
+        return {
+            dashboardExports,
+            reportExports,
+            layerExports,
+            datasourceExports
+        };
+    };
+
+    async function importLayer (layer, datasourceRef, additions) {
+        var params = {
+            _id: layer._id
+        };
+
+        var existingLayer = await connection.get('/api/layers/find-all', params);
+
+        if (existingLayer.items.length > 0) {
+            return;
+        }
+
+        for (const object of layer.objects) {
+            if (object.datasourceID) {
+                object.datasourceID = datasourceRef[object.datasourceID];
+            }
+        }
+
+        var newLayer = await connection.post('/api/layers/create', layer);
+
+        additions.push(newLayer);
+    }
+
+    async function importReport (report, datasourceRef, additions) {
+        var params = {
+            _id: report._id
+        };
+
+        var existingReport = await connection.get('/api/reports/find-all', params);
+
+        if (existingReport.items.length > 0) {
+            return;
+        }
+
+        for (const object of
+            report.properties.columns.concat(
+                report.properties.xkeys,
+                report.properties.ykeys,
+                // report.properties.pivotTable.rows,
+                // report.properties.pivotTable.columns,
+                report.query.columns,
+                report.query.order,
+                report.query.groupFilters
+            )) {
+            // TODO : uncomment the lines above after the merge with pivot table changes
+            if (object && object.datasourceID) {
+                object.datasourceID = datasourceRef[object.datasourceID];
+            }
+        }
+
+        for (const dts of report.query.datasources) {
+            dts.datasourceID = datasourceRef[dts.datasourceID];
+        }
+
+        var newReport = await connection.post('/api/reports/create', report);
+
+        additions.push(newReport);
+    }
+
+    async function importDashboard (dashboard, datasourceRef, additions) {
+        var params = {
+            _id: dashboard._id
+        };
+
+        var existingDashboard = await connection.get('/api/dashboardsv2/find-all', params);
+
+        if (existingDashboard.items.length > 0) {
+            return;
+        }
+
+        for (const report of dashboard.reports) {
+            for (const object of
+                report.properties.columns.concat(
+                    report.properties.xkeys,
+                    report.properties.ykeys,
+                    // report.properties.pivotTable.rows,
+                    // report.properties.pivotTable.columns,
+                    report.query.columns,
+                    report.query.order,
+                    report.query.groupFilters
+                )) {
+                // TODO : uncomment the lines above after the merge with pivot table changes
+                if (object && object.datasourceID) {
+                    object.datasourceID = datasourceRef[object.datasourceID];
+                }
+            }
+
+            for (const dts of report.query.datasources) {
+                dts.datasourceID = datasourceRef[dts.datasourceID];
+            }
+        }
+
+        var newDashboard = await connection.post('/api/dashboardsv2/create', dashboard);
+
+        additions.push(newDashboard);
+    }
+
+    this.importBundle = async function (bundle, datasourceRef) {
+        var additions = [];
+
+        for (const layer of bundle.layerExports) {
+            await importLayer(layer, datasourceRef, additions);
+        }
+
+        for (const report of bundle.reportExports) {
+            await importReport(report, datasourceRef, additions);
+        }
+
+        for (const dashboard of bundle.dashboardExports) {
+            await importDashboard(dashboard, datasourceRef, additions);
+        }
+
+        return additions;
+    };
+
+    this.getDataSources = async function () {
+        const params = {
+            fields: ['_id', 'name']
+        };
+
+        var result = await connection.get('/api/data-sources/find-all', params);
+
+        return result.items;
+    };
+
+    this.getLayers = async function () {
+        var params = {
+            fields: ['_id', 'name']
+        };
+
+        var result = await connection.get('/api/layers/find-all', params);
+
+        return result.items;
+    };
+
+    this.getReports = async function () {
+        var params = {
+            fields: ['_id', 'reportName']
+        };
+
+        var result = await connection.get('/api/reports/find-all', params);
+
+        return result.items;
+    };
+
+    this.getDashboards = async function () {
+        var params = {
+            fields: ['_id', 'dashboardName']
+        };
+
+        var result = await connection.get('/api/dashboardsv2/find-all', params);
+
+        return result.items;
+    };
+});

--- a/public/js/report_v2/model.js
+++ b/public/js/report_v2/model.js
@@ -1,6 +1,6 @@
-/* global XLSX: false, saveAs: false, Blob: false, datenum: false */
+/* global XLSX: false, Blob: false, datenum: false */
 
-app.service('report_v2Model', function (queryModel, c3Charts, reportHtmlWidgets, grid, bsLoadingOverlayService, connection, $routeParams, verticalGrid, pivot) {
+app.service('report_v2Model', function (queryModel, c3Charts, reportHtmlWidgets, grid, bsLoadingOverlayService, connection, $routeParams, verticalGrid, pivot, FileSaver) {
     var report = {};
 
     this.getReportDefinition = async function (id, isLinked) {
@@ -335,7 +335,7 @@ app.service('report_v2Model', function (queryModel, c3Charts, reportHtmlWidgets,
             return buf;
         }
 
-        saveAs(new Blob([s2ab(wbout)], {type: ''}), ws_name + '.xlsx');
+        FileSaver.saveAs(new Blob([s2ab(wbout)], {type: ''}), ws_name + '.xlsx');
     };
 
     function Workbook () {

--- a/public/js/webapp.js
+++ b/public/js/webapp.js
@@ -5,7 +5,8 @@ var app = angular.module('WideStage', [
     'ngRoute', 'ui.sortable', 'gridster', 'ui.layout', 'draganddrop', 'ui.bootstrap', 'ngCsvImport', 'checklist-model', 'ng-nestable',
     'infinite-scroll', 'angular-canv-gauge', 'ui.bootstrap-slider', 'widestage.directives', 'ngSanitize', 'ui.select', 'tg.dynamicDirective', 'angularUUID2', 'vs-repeat',
     'ui.bootstrap.datetimepicker', 'ui.tree', 'page.block', 'gridshore.c3js.chart', 'vAccordion', 'bsLoadingOverlay', 'gg.editableText',
-    'intro.help', 'ngTagsInput', 'ui.codemirror', '720kb.socialshare', 'ngFileUpload', 'pascalprecht.translate', 'colorpicker.module', 'angularSpectrumColorpicker', 'wst.inspector'
+    'intro.help', 'ngTagsInput', 'ui.codemirror', '720kb.socialshare', 'ngFileUpload', 'pascalprecht.translate', 'colorpicker.module', 'angularSpectrumColorpicker', 'wst.inspector',
+    'ngFileSaver',
 ])
     .config(['$routeProvider', '$translateProvider', function ($routeProvider, $translateProvider) {
         // $translateProvider.useUrlLoader('./translations.json');
@@ -280,6 +281,23 @@ var app = angular.module('WideStage', [
         $routeProvider.when('/setup', {
             templateUrl: 'partials/setup/index.html',
             controller: 'setupCtrl'
+        });
+
+        // imports and exports
+
+        $routeProvider.when('/import', {
+            templateUrl: 'partials/io/import.html',
+            controller: 'ioCtrl'
+        });
+
+        $routeProvider.when('/export', {
+            templateUrl: 'partials/io/export.html',
+            controller: 'ioCtrl'
+        });
+
+        $routeProvider.when('/export/download', {
+            templateUrl: 'partials/io/export.html',
+            controller: 'ioCtrl'
         });
     }])
     .factory('$sessionStorage', ['$window', function ($window) {

--- a/public/partials/io/export.html
+++ b/public/partials/io/export.html
@@ -1,0 +1,50 @@
+<h2>Export layers, reports and dashboards </h2>
+
+<div class="container-fluid branded-border-panel"  ng-init="initExport()">
+
+        <h5>Layers</h5>
+
+        <ul>
+            <li ng-repeat="layer in layers">
+                <div>
+                    <input type="checkbox" ng-model="layer.checked">
+                    <span> {{layer.name}}</span>
+                </div>
+            </li>
+        </ul>
+
+        <i>Required Layers for chosen reports and dashboards will be included automatically, there is no need to include them manually.</i>
+        </br>
+        </br>
+
+        <h5>Reports</h5>
+
+        <ul>
+            <li ng-repeat="report in reports">
+                <div>
+                    <input type="checkbox" ng-model="report.checked">
+                    <span> {{report.reportName}}</span>
+                </div>
+            </li>
+        </ul>
+
+        <h5>Dashboards</h5>
+
+        <ul>
+            <li ng-repeat="dashboard in dashboards">
+                <div>
+                    <input type="checkbox" ng-model="dashboard.checked">
+                    <span> {{dashboard.dashboardName}}</span>
+                </div>
+            </li>
+        </ul>
+    
+    <input type="text" ng-model="exportName">
+    .json
+    </br>
+    <button class="btn btn-success" ng-click="downloadExport()">export</button>
+    </br>
+    <a class="btn btn-default" href="/#/home">back</a>
+    
+</div>
+

--- a/public/partials/io/import.html
+++ b/public/partials/io/import.html
@@ -1,0 +1,128 @@
+<h2>Import layers, reports and dashboards </h2>
+
+<div class="container-fluid branded-border-panel" ng-init="initImport()">
+
+    <span ng-if="state === 1">
+        <span ng-if="importFile">
+            <h5>Layers</h5>
+    
+            <ul>
+                <li ng-repeat="layer in importFile.layerExports">
+                    <div>
+                        <span> {{layer.name}}</span>
+                    </div>
+                </li>
+            </ul>
+    
+            <h5>Reports</h5>
+    
+            <ul>
+                <li ng-repeat="report in importFile.reportExports">
+                    <div>
+                        <span> {{report.reportName}}</span>
+                    </div>
+                </li>
+            </ul>
+    
+            <h5>Dashboards</h5>
+    
+            <ul>
+                <li ng-repeat="dashboard in importFile.dashboardExports">
+                    <div>
+                        <span> {{dashboard.dashboardName}}</span>
+                    </div>
+                </li>
+            </ul>
+        </span>
+    
+        <button class="btn btn-success" ng-click="startImport()" ng-show="importFile">import</button>
+        </br>
+        <div class="btn btn-default" ng-app="fileUpload" ngf-select="upload($file)">Choose file to import</div>
+        </br>
+        <a class="btn btn-default" href="/#/home">back</a>
+    </span>
+
+    <span ng-if="state === 2">
+        <h5>Please associate the imported data sources to the local ones</h5>
+    
+            <style type="text/css">
+                #wrap {
+                width:800px;
+                margin:0 auto;
+                }
+                #left_col {
+                float:left;
+                width:500px;
+                }
+                #right_col {
+                float:right;
+                width:300px;
+                }
+            </style>
+            
+            <div id="wrap">
+                <div id="left_col">
+                    <h5>Imported data sources</h5>
+                    <ul>
+                        <li ng-repeat="dts in importFile.datasourceExports">
+                            <div>
+                                <span>{{dts.name}}</span>
+                                <span>
+                                    -> 
+                                    <select ng-model="datasourceMatch[dts._id]" ng-options="dts as dts.name for dts in localDataSources"></select>
+                                </span>
+                            </div>
+                        </li>
+                    </ul>
+
+
+                    </br>
+                    <div ng-show="matchAllDatasourcesMessage">Please match all datasources</div>
+                    </br>
+                    <button ng-click="confirmImport()">confirm</button>
+                    </br>
+                    <button ng-click="cancelImport()">cancel</button>
+
+                </div>
+                <div id="right_col">
+                    <h5>Existing data sources</h5>
+                    <ul>
+                        <li ng-repeat="dts in localDataSources">
+                            <div>
+                                {{dts.name}}
+                            </div>
+                        </li>
+                    </ul>
+
+                </div>
+
+            </div>
+    </span>    
+    
+    <span ng-if="state === 3">
+        <h5>Import successful</h5>
+        <div ng-if="created.length">
+            The following items have been created : </br>
+            <ul>
+                <li ng-repeat="item in created">
+                    {{item.item.name || item.item.reportName}}
+                </li>
+            </ul>
+        </div>
+        <div ng-if="!created.length">
+            No new item has been created.
+        </div>
+        <button ng-click="initImport()">Import new file</button>
+        <a class="button" href="/#/home">Back to main page</a>
+    </span>
+
+    <span ng-if="state === 4">
+        <h5>An error has occurred</h5>
+        <button ng-click="console.log(creationError)">log error in console</button>
+        </br>
+        <button ng-click="initImport()">Import new file</button>
+        <a class="button" href="/#/home">Back to main page</a>
+    </span>
+
+</div>
+

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -118,7 +118,9 @@
 <!--excel export -->
 <script src="js-xlsx/dist/xlsx.core.min.js"></script>
 <!--file saver -->
-<script src="file-saver/FileSaver.min.js"></script>
+<!-- <script src="file-saver/FileSaver.min.js"></script> -->
+<!--file saver -->
+<script src="angular-file-saver/dist/angular-file-saver.bundle.min.js"></script>
 <!--angular-csv-import.js-->
 <script src="angular-csv-import/dist/angular-csv-import.min.js"></script>
 <!--introhelp-->
@@ -225,6 +227,8 @@
 <script type="text/javascript" src="js/widgets/wstImage.js"></script>
 <script type="text/javascript" src="js/widgets/wstHidden.js"></script>
 <script type="text/javascript" src="js/setup/controller.js"></script>
+<script type="text/javascript" src="js/io/controller.js"></script>
+<script type="text/javascript" src="js/io/model.js"></script>
 <script type="text/javascript" src="js/files/controller.js"></script>
 
 


### PR DESCRIPTION
Layers, reports and dashboards can now be exported and imported to and from
different instances of Urungi.
The import and export pages were created in the frontend, and can be accessed
with their urls : "#/import" and "#/export"
They are not linked to within the main urungi interface
Graphic work is minimal. For now, the feature is only meant to be used
for urungi installation.