### PR TITLE
Fix isUsable check in report editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed queries with multiple filters
+- Fixed a bug that prevented to add new columns to existing reports
 
 ### Removed
 

--- a/server/custom/reports/model.js
+++ b/server/custom/reports/model.js
@@ -3,7 +3,6 @@ var mongoose = require('mongoose');
 const ReportColumnSchema = new mongoose.Schema({
     aggregation: String,
     collectionID: String,
-    component: Number,
     data_type: String,
     doNotStack: Boolean,
     elementID: String,
@@ -51,7 +50,6 @@ const ReportQuerySchema = new mongoose.Schema({
 
 const ReportPropertiesSchema = new mongoose.Schema({
     columns: [ ReportColumnSchema ],
-    connectedComponent: Number, // FIXME This should not be stored
     filters: [ ReportFilterSchema ],
     height: Number,
     legendPosition: String,


### PR DESCRIPTION
The 'component' property in reports can get out of sync if the layer is
modified after the report creation.

The solution is to not store 'component' at all in the report, and check
the corresponding objects in the layer instead.