### PR TITLE
Fix some graphical issues with grid and vGrid in dashboards

### DIFF
--- a/public/js/dashboardv2/controller.js
+++ b/public/js/dashboardv2/controller.js
@@ -653,16 +653,6 @@ angular.module('app').controller('dashBoardv2Ctrl', function ($scope, $location,
         }
     };
 
-    $scope.gridGetMoreData = function (reportID) {
-        for (var i in $scope.selectedDashboard.reports) {
-            if ($scope.selectedDashboard.reports[i].id === reportID) {
-                if (!$scope.selectedDashboard.reports[i].lastLoadedPage) { $scope.selectedDashboard.reports[i].lastLoadedPage = 2; } else { $scope.selectedDashboard.reports[i].lastLoadedPage += 1; }
-
-                reportModel.getReportDataNextPage($scope.selectedDashboard.reports[i], $scope.selectedDashboard.reports[i].lastLoadedPage);
-            }
-        }
-    };
-
     $scope.$on('element.reselected', function (e, node) {
         $scope.tabs.selected = 'settings';
     });

--- a/public/js/report/controller.js
+++ b/public/js/report/controller.js
@@ -38,15 +38,6 @@ angular.module('app').controller('reportCtrl', function ($scope, connection, $co
     /*
     *   Initialisation
     */
-
-    $scope.initReportList = function () {
-        $scope.navigation.page = 1;
-
-        return $scope.getReports().then(function () {
-            $scope.mode = 'list';
-        });
-    };
-
     $scope.initReportEdit = function () {
         // FIXME There should be another way...
         if (/dashboards/.test($location.path())) {
@@ -822,11 +813,6 @@ angular.module('app').controller('reportCtrl', function ($scope, connection, $co
         }
 
         return available;
-    };
-
-    $scope.gridGetMoreData = function (reportID) {
-        $scope.navigation.page += 1;
-        reportModel.getReportDataNextPage($scope.selectedReport, $scope.navigation.page);
     };
 
     $scope.setSortType = function (field, type) {

--- a/public/js/report/model.js
+++ b/public/js/report/model.js
@@ -277,10 +277,10 @@ angular.module('app').service('reportModel', function ($q, connection, uuid, Fil
 
         var containerID = 'REPORT_CONTAINER_' + reportID;
 
-        var html = '<div page-block  class="container-fluid featurette ndContainer"  ndType="container" style="height:100%;padding:0px;">' +
+        var html = '<div page-block class="container-fluid featurette ndContainer"  ndType="container" style="height:100%;padding:0px;">' +
                         '<div page-block class="col-md-12 ndContainer" ndType="column" style="height:100%;padding:0px;">' +
                             '<div page-block class="container-fluid" id="' + containerID +
-                             '" report-view report="getReport(\'' + reportID + '\')" style="padding:0px;position: relative;height: 100%;font-size:30px;"></div>' +
+                             '" report-view report="getReport(\'' + reportID + '\')" style="padding:0px;position: relative;height: 100%;"></div>' +
                         '</div>' +
                     '</div>';
 

--- a/public/js/report/services/grid.js
+++ b/public/js/report/services/grid.js
@@ -16,11 +16,6 @@ angular.module('app').service('grid', function (gettextCatalog) {
         }
 
         var theProperties = report.properties;
-        var pageBlock = 'page-block';
-
-        if (mode === 'preview') {
-            pageBlock = '';
-        }
 
         var reportStyle = 'width:100%;padding-left:0px;padding-right:0px;';
         var headerStyle = 'width:100%;padding-left:0px;background-color:#ccc;';
@@ -34,7 +29,7 @@ angular.module('app').service('grid', function (gettextCatalog) {
 
         if (theProperties) {
             reportStyle += 'background-color: #fff;';
-            // reportStyle += 'height:'+theProperties.height+'px;';
+            reportStyle += 'min-height: 200px;';
 
             const rowHeight = 35;
             columnDefaultStyle += 'height: ' + rowHeight + 'px;';
@@ -48,7 +43,7 @@ angular.module('app').service('grid', function (gettextCatalog) {
             columnDefaultStyle += 'border-bottom: 2px solid #ccc;';
         }
 
-        var htmlCode = '<div ' + pageBlock + ' id="REPORT_' + id + '" ndType="extendedGrid" class="container-fluid report-container" style="' + reportStyle + '">';
+        var htmlCode = '<div id="REPORT_' + id + '" class="container-fluid report-container" style="' + reportStyle + '">';
 
         columns = report.properties.columns;
 
@@ -61,7 +56,7 @@ angular.module('app').service('grid', function (gettextCatalog) {
         }
         htmlCode += '</div>';
 
-        htmlCode += '<div vs-repeat style="width:100%;overflow-y: scroll;border: 1px solid #ccc;align-items: stretch;position: absolute;bottom: 0px;top: 60px;" scrolly="gridGetMoreData(\'' + id + '\')">';
+        htmlCode += '<div vs-repeat style="width:100%;overflow-y: scroll;border: 1px solid #ccc;align-items: stretch;position: absolute;bottom: 0px;top: 60px;">';
 
         htmlCode += '<div ndType="repeaterGridItems" class="repeater-data container-fluid" ng-repeat="item in report.query.data | filter:theFilter | orderBy:report.predicate:report.reverse  " style="' + rowStyle + '"  >';
 
@@ -162,18 +157,4 @@ angular.module('app').service('grid', function (gettextCatalog) {
 
         return htmlCode;
     }
-});
-
-angular.module('app').directive('scrolly', function () {
-    return {
-        restrict: 'A',
-        link: function (scope, element, attrs) {
-            var raw = element[0];
-            element.bind('scroll', function () {
-                if (raw.scrollTop + raw.offsetHeight > raw.scrollHeight) {
-                    scope.$apply(attrs.scrolly);
-                }
-            });
-        }
-    };
 });

--- a/public/js/report/services/vGrid.js
+++ b/public/js/report/services/vGrid.js
@@ -8,13 +8,9 @@ angular.module('app').service('verticalGrid', function (dataElements, gettextCat
         }
 
         var theProperties = report.properties;
-        var pageBlock = 'page-block';
-
-        if (mode === 'preview') {
-            pageBlock = '';
-        }
 
         var reportStyle = 'width:100%;padding-left:0px;padding-right:0px;';
+        reportStyle += 'min-height: 200px;';
         var rowStyle = 'width:100%;padding:0px';
 
         if (!theProperties.height) theProperties.height = 400;
@@ -23,11 +19,11 @@ angular.module('app').service('verticalGrid', function (dataElements, gettextCat
             reportStyle += 'background-color: #fff;';
         }
 
-        var htmlCode = '<div ' + pageBlock + ' id="REPORT_' + id + '" ndType="extendedGrid" class="container-fluid report-container" style="' + reportStyle + '">';
+        var htmlCode = '<div id="REPORT_' + id + '" class="container-fluid report-container" style="' + reportStyle + '">';
 
         const columns = report.properties.columns;
 
-        htmlCode += '<div vs-repeat style="width:100%;overflow-y: auto;border: 1px solid #ccc;align-items: stretch;position: absolute;bottom: 0px;top: 0px;" scrolly="gridGetMoreData(\'' + id + '\')">';
+        htmlCode += '<div vs-repeat style="width:100%;overflow-y: auto;border: 1px solid #ccc;align-items: stretch;position: absolute;bottom: 0px;top: 0px;">';
 
         htmlCode += '<div ndType="repeaterGridItems" class="repeater-data container-fluid" ng-repeat="item in report.query.data | filter:theFilter | orderBy:report.predicate:report.reverse  " style="' + rowStyle + '"  >';
 


### PR DESCRIPTION
- Remove inline style `font-size: 30px` for report-view block
- Remove page-block attribute from grid and vGrid containers. This
  prevent styling these containers in dashboard editor (which is useless
  because the changes are not saved)
- Set a minimum height for grid and vGrid. This prevents data to be
  completely hidden when the container has no height defined
- Remove dead code related to grid and vGrid (scrolly directive and
some functions)

Fixes #115