### PR TITLE
Use a default of 'and' for conditionType when not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that prevented the column's type (spline, bar, area, ...) to be
   saved
 - Columns and rows of pivot table are now sorted
+- Fixed a bug in SQL query builder when using date filters
 
 ## [1.2.0] - 2019-08-26
 

--- a/server/core/sqlQueryBuilder.js
+++ b/server/core/sqlQueryBuilder.js
@@ -188,7 +188,7 @@ class SqlQueryBuilder {
                     return qb.whereBetween(field, [filter.criterion.text1, filter.criterion.text2]);
                 }
             } else {
-                var ct = filter.conditionType;
+                var ct = filter.conditionType || 'and';
                 if (negate) {
                     ct = (ct === 'and' || ct === 'andNot') ? ((ct === 'and') ? 'andNot' : 'and') : ((ct === 'or') ? 'orNot' : 'or');
                 }
@@ -213,7 +213,7 @@ class SqlQueryBuilder {
                     return qb.whereIn(field, filter.criterion.textList);
                 }
             } else {
-                var ct = filter.conditionType;
+                var ct = filter.conditionType || 'and';
                 if (negate) {
                     ct = (ct === 'and' || ct === 'andNot') ? ((ct === 'and') ? 'andNot' : 'and') : ((ct === 'or') ? 'orNot' : 'or');
                 }
@@ -238,7 +238,7 @@ class SqlQueryBuilder {
                     return qb.whereNull(field);
                 }
             } else {
-                var ct = filter.conditionType;
+                var ct = filter.conditionType || 'and';
                 if (negate) {
                     ct = (ct === 'and' || ct === 'andNot') ? ((ct === 'and') ? 'andNot' : 'and') : ((ct === 'or') ? 'orNot' : 'or');
                 }
@@ -332,7 +332,8 @@ class SqlQueryBuilder {
             if (first) {
                 return qb.where(builderFunction);
             } else {
-                switch (filter.conditionType) {
+                const conditionType = filter.conditionType || 'and';
+                switch (conditionType) {
                 case 'and':
                     return qb.where(builderFunction);
                 case 'or':


### PR DESCRIPTION
conditionType is currently not modifiable in the interface, sometimes it
is set, and sometimes not. So we need to use a default value for it when
it is not set.

Fixes #122