### PR TITLE
Remove "Remember Me" feature at login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10966,26 +10966,6 @@
         }
       }
     },
-    "passport-remember-me": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/passport-remember-me/-/passport-remember-me-0.0.1.tgz",
-      "integrity": "sha1-CqYJXIJID0RhlFau82PMuSm8K8M=",
-      "requires": {
-        "passport": "~0.1.1",
-        "pkginfo": "0.2.x"
-      },
-      "dependencies": {
-        "passport": {
-          "version": "0.1.18",
-          "resolved": "https://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
-          "integrity": "sha1-yCZEedy2QUytu2Z1LRKzfgtlJaE=",
-          "requires": {
-            "pause": "0.0.1",
-            "pkginfo": "0.2.x"
-          }
-        }
-      }
-    },
     "passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
@@ -11200,11 +11180,6 @@
       "requires": {
         "find-up": "^2.1.0"
       }
-    },
-    "pkginfo": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
-      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
     },
     "plugin-error": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "passport": "^0.4.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "~1.0.0",
-    "passport-remember-me": "~0.0.1",
     "password-generator": "^2.2.0",
     "pg": "^7.12.1",
     "pivottable": "^2.23.0",

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -23,25 +23,19 @@
 
     angular.module('app-login').controller('PublicCtrl', PublicCtrl);
 
-    PublicCtrl.$inject = ['$scope', '$http', '$window', 'base', 'localStorage'];
+    PublicCtrl.$inject = ['$scope', '$http', '$window', 'base'];
 
-    function PublicCtrl ($scope, $http, $window, base, localStorage) {
-        var user = localStorage.getObject('user');
-
+    function PublicCtrl ($scope, $http, $window, base) {
         $scope.loginError = false;
         $scope.errorLoginMessage = '';
         $scope.login = function () {
-            var user = { userName: $scope.userName, password: $scope.password, remember_me: $scope.rememberMe, companyID: $('#companyID').attr('value') };
+            var user = { userName: $scope.userName, password: $scope.password, companyID: $('#companyID').attr('value') };
 
             if ($scope.userName !== undefined || $scope.password !== undefined) {
                 $http({ method: 'POST', url: '/api/login', data: user, withCredentials: true })
                     .then(function (data, status, headers, config) {
                         $scope.loginError = false;
 
-                        if ($scope.rememberMe) {
-                            // FIXME This stores the user password in local storage !
-                            localStorage.setObject('user', user);
-                        }
                         $window.location.href = base + '/home';
                     })
                     .catch(function (data, status, headers, config) {
@@ -50,13 +44,5 @@
                     });
             }
         };
-
-        if (user) {
-            $scope.userName = user.userName;
-            $scope.password = user.password;
-            $scope.rememberMe = user.remember_me;
-
-            $scope.login();
-        }
     }
 })();

--- a/server/app.js
+++ b/server/app.js
@@ -56,17 +56,11 @@ var bodyParser = require('body-parser');
 app.use(bodyParser.json({ limit: '50mb' })); // get information from html forms
 app.use(bodyParser.urlencoded({ extended: true }));
 
-var authentication = true;
-
-global.authentication = authentication;
 global.logFailLogin = true;
 global.logSuccessLogin = true;
 
-if (authentication) {
-    app.use(passport.initialize());
-    app.use(passport.session());
-    app.use(passport.authenticate('remember-me'));
-}
+app.use(passport.initialize());
+app.use(passport.session());
 
 require('./config/passport')(passport);
 

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -2,7 +2,6 @@ const config = require('config');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 
 const LocalStrategy = require('passport-local').Strategy;
-const RememberMeStrategy = require('passport-remember-me').Strategy;
 
 const mongoose = require('mongoose');
 const User = mongoose.model('User');
@@ -23,29 +22,6 @@ module.exports = function (passport) {
     function (username, password, done) {
         User.isValidUserPassword(username, password, done);
     }));
-
-    passport.use(new RememberMeStrategy(
-        function (token, done) {
-            User.findOne({ accessToken: token }, {}, function (err, user) {
-                if (err) { return done(err); }
-                if (!user) { return done(null, false); }
-                return done(null, user);
-            });
-        },
-        function (user, done) {
-            var token = ((Math.random() * Math.pow(36, 10) << 0).toString(36)).substr(-8);
-            User.updateOne({
-                _id: user.id
-            }, {
-                $set: {
-                    accessToken: token
-                }
-            }, function (err) {
-                if (err) { return done(err); }
-                return done(null, token);
-            });
-        }
-    ));
 
     if (config.has('google')) {
         passport.use(new GoogleStrategy({

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -67,12 +67,6 @@ function authenticate (passport, User, req, res, next) {
                 last_login_ip: req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.socket.remoteAddress || req.connection.socket.remoteAddress
             };
 
-            if (req.body.remember_me) {
-                var token = ((Math.random() * Math.pow(36, 10) << 0).toString(36)).substr(-8);
-                loginData.accessToken = token;
-                res.cookie('remember_me', token, { path: '/', httpOnly: true, maxAge: 604800000 }); // 7 days
-            }
-
             // insert the company's Data into the user to avoid a 2nd server query'
 
             Company.findOne({ companyID: user.companyID }, {}, function (err, company) {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -18,7 +18,6 @@ const userSchema = new mongoose.Schema({
     filters: [],
     contextHelp: [],
     dialogs: [],
-    accessToken: String,
     startDate: { type: Date, default: Date.now },
     endDate: { type: Date },
     history: String,

--- a/server/routes/api/user.js
+++ b/server/routes/api/user.js
@@ -128,7 +128,6 @@ function setContextHelp (req, res) {
 
 function logout (req, res) {
     req.logOut();
-    res.clearCookie('remember_me');
     res.sendStatus(204);
 }
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -49,13 +49,6 @@
                     </div>
 
                     <div class="form-group">
-                        <label class="inline">
-                            <input type="checkbox" name="remember_me" ng-model="rememberMe" />
-                            <span style="font-weight: normal; color: #ccc;" translate>Remember Me</span>
-                        </label>
-                    </div>
-
-                    <div class="form-group">
                         <button id="login-btn" ng-click="login()" class="btn  btn-block text-left">
                             <i class="fa fa-lock"></i>
                             <span translate>Log In</span>


### PR DESCRIPTION
It was badly implemented and not secure at all:
- password was stored in plain text in browser's local storage
- the access token stored in remember_me cookie was also stored in plain
  text in mongo database, allowing anyone with a copy of the database to
  impersonate a user

For security reasons, it is better to remove this feature until a better
implementation is made