### PR TITLE
Move notifications away from action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CSS class "scrollable-dropdown-menu" for filter suggestions and filter type input
 - Now it's possible to delete a role, even if it contains users (with mention on modal)
 
+### Changed
+
+- Moved notifications from top-right corner to bottom-right corner because they
+  were hiding action buttons
+
 ### Fixed
 
 - Fixed XLSX export miscalculation of column id which caused some columns to

--- a/public/js/core/notify.service.js
+++ b/public/js/core/notify.service.js
@@ -10,7 +10,7 @@
 
         // define the default stack display for notifications
         PNotify.defaults.stack = new PNotify.Stack({
-            dir1: 'down',
+            dir1: 'up',
             dir2: 'left',
             firstpos1: 25,
             firstpos2: 25,


### PR DESCRIPTION
Instead of appearing in the top-right corner of the screen, they now appear in the bottom-right corner