### PR TITLE
Fix drag and drop issue with images within dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix drag and drop issue with images within dashboards
+
 ## [3.1.1] - 2022-07-20
 
 ### Fixed

--- a/public/js/dashboards/dashboard-image.component.js
+++ b/public/js/dashboards/dashboard-image.component.js
@@ -8,7 +8,7 @@
         },
         controller: DashboardImageController,
         controllerAs: 'vm',
-        template: '<img class="img-responsive" ng-src="{{ vm.url }}">',
+        template: '<img class="img-responsive" draggable="false" ng-src="{{ vm.url }}">',
     });
 
     DashboardImageController.$inject = ['$element', '$uibModal'];


### PR DESCRIPTION
Sometimes, when dragging an image from inside the dashboard to the same dashboard, the #designArea div would be duplicated, causing display issues.
It looks like a bug of Firefox only (tested with version 105.0.3)

The bug is fixed by disabling drag on images inside dashboards